### PR TITLE
Fixed SMS MFA activation

### DIFF
--- a/okta/FactorsClient.py
+++ b/okta/FactorsClient.py
@@ -115,8 +115,10 @@ class FactorsClient(ApiClient):
         """
         request = {
             'passCode': passcode,
-            'next_passcode': next_passcode
         }
+        if next_passcode is not None:
+            request['next_passcode'] = next_passcode
+            
         response = ApiClient.post_path(self, '/{0}/factors/{1}/lifecycle/activate'.format(user_id, user_factor_id), request)
         return Utils.deserialize(response.text, Factor)
 


### PR DESCRIPTION
The OKTA API was returning E0000003 (The request body was not well-formed: Could not read JSON) when enrolling users in SMS MFA, presumably because it wasn't expecting the `next_passcode` key. This only included `next_passcode` when it is passed to `activate_factor`.