### PR TITLE
:bug: Fixes create_user method for activate param 

### DIFF
--- a/okta/UsersClient.py
+++ b/okta/UsersClient.py
@@ -64,7 +64,7 @@ class UsersClient(ApiClient):
         response = ApiClient.put_path(self, '/{0}'.format(uid), user)
         return Utils.deserialize(response.text, User)
 
-    def create_user(self, user, activate=False):
+    def create_user(self, user, activate=None):
         """Create a user
 
         :param user: the data to create a user
@@ -73,7 +73,7 @@ class UsersClient(ApiClient):
         :type activate: bool
         :rtype: User
         """
-        if activate is False:
+        if activate is None:
             response = ApiClient.post_path(self, '/', user)
         else:
             params = {


### PR DESCRIPTION
Hi everyone, I found something that I think it is a bug. The issue happen when you create a user without credentials

Steps to reproduce the issue:
1. Execute the following script (it is something similar of what is explained in the oktasdk [documentation](http://developer.okta.com/docs/sdk/core/python_api_sdk/quickstart.html#create-a-user))
```python
import okta
from okta.models.user import User
users_client = okta.UsersClient(os.environ['OKTA_BASE_URL'], os.environ['OKTA_API_TOKEN'])

user = User(login='ex@example.com', email='ex@example.com', firstName='saml', lastName='jackson')

users_client.create_user(user, activate=False)
```
2. Verify the user created in the Okta instance.
3. The user should be created with status STAGED but it is created with status PROVISIONED.

I only changed one line of code on the create_user method, basically, if activate is True, it will make a request to okta without query parameters (this will create a user with status PROVISIONED as described in OKTA API documentation [here](http://developer.okta.com/docs/api/resources/users.html#create-user-without-credentials)), if activate is False it will create a request to Okta with the query parameter activate=false.

Please correct me if I am understanding something wrong.
Also, I marked this PR with [DO NOT MERGE] because this change breaks a test, I tried to fix it but I couldn't find a way to update the tapes, I would like some guidance/instructions on how to do that if possible.

